### PR TITLE
fix(renderer): undefined template ref fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,8 +1199,6 @@ describe('VComponentFactory', () => {
 - VInit does not work without callback yet
 - Running tests with vComponentFactory may cause Jest open handles issue. As a workaround, you can enable fake timers in
   the Jest config or explicitly disable real timers in your tests (do not forget to re-enable them!).
-- VCheck is always executed internally when the dom is being built, while some values may not be set yet;
-- In some cases the template ref can be undefined. The renderer should not throw an error.
 
 # Literature
 

--- a/src/core/renderer/__tests__/v-internal-renderer.spec.ts
+++ b/src/core/renderer/__tests__/v-internal-renderer.spec.ts
@@ -1,0 +1,51 @@
+import {VComponent} from "../../component/v-component";
+import {vComponentFactory, VTestComponent} from "../../../testing";
+
+@VComponent({
+    selector: 'check-component',
+    styles: [],
+    html: `<v-check if="isTrue()">
+            <true><span>{{ trueValue }}</span></true>
+            <false><span>{{ undefinedValue }}</span></false>
+        </v-check>`
+})
+export class CheckComponent {
+
+    trueValue = "True";
+    undefinedValue: string = undefined;
+
+    isTrue(): boolean {
+        return true;
+    }
+}
+
+@VComponent({
+    selector: 'switch-component',
+    styles: [],
+    html: `<v-switch condition="{{ myCondition }}">
+    <v-case if="someCondition"><span>True</span></v-case>
+    <v-case-default><span>False</span></v-case-default>
+</v-switch>`
+})
+export class SwitchComponent {
+    myCondition = 'someCondition';
+}
+
+describe('VInternalRenderer', () => {
+
+    it('should render true value while false is undefined', () => {
+        const createComponent = vComponentFactory<CheckComponent>({
+            component: CheckComponent
+        });
+        const component: VTestComponent<CheckComponent> = createComponent();
+        expect(component.html).toEqual('<span>True</span>');
+    });
+
+    it('should render case with template ref', () => {
+        const createComponent = vComponentFactory<SwitchComponent>({
+            component: SwitchComponent
+        });
+        const component: VTestComponent<SwitchComponent> = createComponent();
+        expect(component.html).toEqual('<span>True</span>');
+    });
+});

--- a/src/core/template-engine/__tests__/v-internal-template-engine.test.ts
+++ b/src/core/template-engine/__tests__/v-internal-template-engine.test.ts
@@ -1,6 +1,5 @@
 import {VInternalTemplate} from "../v-internal-template";
 import {VInternalTemplateEngine} from "../v-internal-template-engine";
-import {VTemplateRenderException} from "../v-template-render-exception";
 
 describe('VInternalTemplateEngine', () => {
 
@@ -59,10 +58,10 @@ describe('VInternalTemplateEngine', () => {
     });
 
     describe('Missing data', () => {
-        it.each([{}, undefined])('should throw a render exception when there is a interpolation and data is %s', (data) => {
+        it.each([{}, undefined])('should return empty string when there is a interpolation and data is %s', (data) => {
             const template = createTemplate('Hello, my name is {{ name }}');
-            const render = () => VInternalTemplateEngine.render(template, data);
-            expect(render).toThrow(new VTemplateRenderException(`Cannot find value for template reference '{{ name }}'.`));
+            const result = VInternalTemplateEngine.render(template, data);
+            expect(result).toEqual('Hello, my name is ');
         });
     });
 

--- a/src/core/template-engine/v-internal-template-engine.ts
+++ b/src/core/template-engine/v-internal-template-engine.ts
@@ -1,6 +1,5 @@
 import {VInternalTemplate} from "./v-internal-template";
-import {VTemplateRenderException} from "./v-template-render-exception";
-import {getDefinedOrElse, getNestedPropertyByStringPath} from "../util/v-internal-object-util";
+import {getDefinedOrElseDefault, getNestedPropertyByStringPath} from "../util/v-internal-object-util";
 import {escapeBracketsInRegex} from "../util/v-internal-regex-util";
 import {filterXSS} from "xss";
 
@@ -20,9 +19,11 @@ export class VInternalTemplateEngine {
             const rawValue = typeof data === 'object'
                 ? getNestedPropertyByStringPath(data, templateReference)
                 : data;
-            const value = getDefinedOrElse<any>(rawValue, () => {
-                throw new VTemplateRenderException(`Cannot find value for template reference '${match}'.`)
-            });
+
+            // Originally, this condition was throwing an exception. However, with conditional segments, template
+            // refs may change over time. This means that the ref will be set later in time. This is totally valid.
+            // So, if the value does not exist yet, we just return an empty string (YN).
+            const value = getDefinedOrElseDefault<any>(rawValue, '');
             return filterXSS(`${value}`);
         });
     }

--- a/src/core/util/v-internal-object-util.ts
+++ b/src/core/util/v-internal-object-util.ts
@@ -46,6 +46,14 @@ export const getDefinedOrElse = <T>(obj: T, fn: () => void): T => {
     }
 }
 
+export const getDefinedOrElseDefault = <T>(obj: T, defaultValue: T): T => {
+    if (obj !== undefined && obj !== null) {
+        return obj;
+    } else {
+        return defaultValue;
+    }
+}
+
 export const doWhenDefined = <T>(obj: T, fn: (v?: T) => void): void => {
     if (obj !== undefined && obj !== null) {
         fn(obj);


### PR DESCRIPTION
Previously, undefined template refs caused rendering exceptions, since the template engine was not
able to parse the reference. However, this situation is totally valid, because template refs may not
exist initially due to conditional segments. Therefore, we just return an empty string if the
template ref does not exist (yet).

BREAKING CHANGE: Undefined template refs are now accepted by the template engine