### PR TITLE
refactor(dark mode): change global dark mode implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ following:
     - `style`: just plain css.
     - `href`: a link to a remote stylesheet. Thus, a href should start with 'http'. Also, it is possible to pass
       integrity and crossorigin values  (see below).
-- `darkModeEnabled` (optional): global method to initialize app-wide dark mode (see [dark mode](#dark-mode)).
+- `darkMode` (optional): global config object to initialize app-wide dark mode (see [dark mode](#dark-mode)).
 - `pipes` (optional): custom pipes (see [create custom pipes](#create-custom-pipes))
 
 For instance, if you want to use [Bulma](https://bulma.io), just add the following:
@@ -1025,7 +1025,7 @@ dark apps more than light apps, and for some it is even a necessity to use an ap
 ### Set up dark mode
 
 Luckily, Vienna comes with dark mode out of the box. There are two ways to enable dark mode. The easiest way is to set
-up dark mode in your application config by using the so-called `darkModeEnabled` hook. It is just a method that should
+up dark mode in your application config by using the so-called `isDarkModeEnabled` hook. It is just a method that should
 return true or false. If it returns true, dark mode will be enabled for the whole application. For instance:
 
 `application.ts`
@@ -1034,9 +1034,11 @@ return true or false. If it returns true, dark mode will be enabled for the whol
 @VApplication({
     declarations: [],
     routes: [],
-    darkModeEnabled: () => {
-      // ... Some custom logic here. 
-      return true; 
+    darkMode: {
+      isDarkModeEnabled: () => {
+        // ... Some custom logic here. 
+        return true; 
+      }
     }
 })
 export class Application {}
@@ -1106,8 +1108,10 @@ config:
 @VApplication({
     declarations: [],
     routes: [],
-    darkModeEnabled: () => {...},
-    darkModeClassOverride: 'my-custom-dark-mode-class'
+    darkMode: {
+      isDarkModeEnabled: () => {...},
+      darkModeClassOverride: 'my-custom-dark-mode-class'
+    }
 })
 export class Application {}
 ```

--- a/src/core/application/v-application-config.ts
+++ b/src/core/application/v-application-config.ts
@@ -7,6 +7,7 @@ import {VGlobalStyles} from "./v-global-styles";
 import {VApplicationPlugins} from "./v-application-plugins";
 import {VPipeTransform} from "../pipe/v-pipe-transform";
 import {VI18nConfig} from "./v-i18n-config";
+import {VDarkModeOptions} from "./v-dark-mode-options";
 
 export interface VApplicationConfig {
     declarations: Type<VComponentType>[];
@@ -14,8 +15,7 @@ export interface VApplicationConfig {
     routeNotFoundStrategy?: VRouteNotFoundStrategy | VRouteNotFoundRedirect;
     rootElementSelector?: string;
     globalStyles?: VGlobalStyles;
-    darkModeEnabled?: () => boolean;
-    darkModeClassOverride?: string;
+    darkMode?: VDarkModeOptions;
     plugins?: VApplicationPlugins;
     pipes?: Type<VPipeTransform>[];
     i18n?: VI18nConfig;

--- a/src/core/application/v-application.ts
+++ b/src/core/application/v-application.ts
@@ -107,14 +107,20 @@ export function VApplication(config: VApplicationConfig) {
             }
 
             private initializeDarkMode(): void {
-                const isDarkModeEnabledInConfig = config.darkModeEnabled ? config.darkModeEnabled() : false;
+                if (!config.darkMode) {
+                    return;
+                }
+
+                const isDarkModeEnabledInConfig = config.darkMode.isDarkModeEnabled
+                    ? config.darkMode.isDarkModeEnabled()
+                    : false;
                 if (isDarkModeEnabledInConfig) {
                     this._darkModeService.enableDarkMode();
                 } else {
                     this._darkModeService.disableDarkMode();
                 }
 
-                const darkModeClassOverride = config.darkModeClassOverride;
+                const darkModeClassOverride = config.darkMode.darkModeClassOverride;
                 if (darkModeClassOverride) {
                     this._darkModeService.overrideGlobalDarkModeClass(darkModeClassOverride);
                 }

--- a/src/core/application/v-dark-mode-options.ts
+++ b/src/core/application/v-dark-mode-options.ts
@@ -1,0 +1,4 @@
+export interface VDarkModeOptions {
+    isDarkModeEnabled?: () => boolean;
+    darkModeClassOverride?: string;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,7 @@
 // Public Vienna framework api
 export * from './application/v-application';
 export * from './application/v-application-config';
+export * from './application/v-dark-mode-options';
 export * from './application/v-global-inline-style';
 export * from './application/v-global-style-link';
 export * from './application/v-global-styles';


### PR DESCRIPTION
BREAKING CHANGE: Dark mode configuration should be set in a so-called dark mode object